### PR TITLE
[rabbitmq] Docker image updates - 2024-02-16-120410

### DIFF
--- a/3/debian11/3.11/Dockerfile
+++ b/3/debian11/3.11/Dockerfile
@@ -145,10 +145,10 @@ RUN set -eux; \
   ln -sf "$RABBITMQ_DATA_DIR/.erlang.cookie" /root/.erlang.cookie
 
 
-ENV RABBITMQ_VERSION 3.11.23
+ENV RABBITMQ_VERSION 3.11.28
 ENV RABBITMQ_HOME=/opt/rabbitmq
 
-ENV C2D_RELEASE 3.11.23
+ENV C2D_RELEASE 3.11.28
 
 # Add RabbitMQ to PATH, send all logs to TTY
 ENV PATH=$RABBITMQ_HOME/sbin:$PATH \

--- a/3/debian11/3.12/Dockerfile
+++ b/3/debian11/3.12/Dockerfile
@@ -145,10 +145,10 @@ RUN set -eux; \
   ln -sf "$RABBITMQ_DATA_DIR/.erlang.cookie" /root/.erlang.cookie
 
 
-ENV RABBITMQ_VERSION 3.12.4
+ENV RABBITMQ_VERSION 3.12.12
 ENV RABBITMQ_HOME=/opt/rabbitmq
 
-ENV C2D_RELEASE 3.12.4
+ENV C2D_RELEASE 3.12.12
 
 # Add RabbitMQ to PATH, send all logs to TTY
 ENV PATH=$RABBITMQ_HOME/sbin:$PATH \


### PR DESCRIPTION
Update RabbitMQ to the latest versions to fix [CVE-2023-46118](https://github.com/rabbitmq/rabbitmq-server/security/advisories/GHSA-w6cq-9cf4-gqpg).